### PR TITLE
fix(Docker): Setting memory limit at 4GB

### DIFF
--- a/production/docker/docker-compose.yml
+++ b/production/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       options:
         max-size: '10m'
         max-file: '10'
-    #mem_limit: 500mb
+    mem_limit: 4000mb
     links:
       - mongo-ipfs-service
     ports:


### PR DESCRIPTION
[There appears to be a memory leak in libp2p or helia](https://github.com/libp2p/js-libp2p/discussions/2509). This change sets a memory limit of 4GB on the Docker container. When the IPFS node hits that memory limit, Docker will restart the app. Not an ideal solution, but effective in the short term.