### PR TITLE
fix(webrtc): Disabling webRTC due to bug

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 The MIT License (MIT)
-Copyright (c) 2021-2023 Permissionless Software Foundation
+Copyright (c) 2021-2024 Permissionless Software Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/adapters/ipfs/ipfs.js
+++ b/src/adapters/ipfs/ipfs.js
@@ -21,12 +21,12 @@ import { yamux } from '@chainsafe/libp2p-yamux'
 // import { identifyService } from 'libp2p/identify'
 import { identify } from '@libp2p/identify'
 // import { circuitRelayServer, circuitRelayTransport } from 'libp2p/circuit-relay'
-import { circuitRelayServer, circuitRelayTransport } from '@libp2p/circuit-relay-v2'
+import { circuitRelayServer } from '@libp2p/circuit-relay-v2'
 import { gossipsub } from '@chainsafe/libp2p-gossipsub'
 import { webSockets } from '@libp2p/websockets'
 import { publicIpv4 } from 'public-ip'
 import { multiaddr } from '@multiformats/multiaddr'
-import { webRTC } from '@libp2p/webrtc'
+// import { webRTC } from '@libp2p/webrtc'
 import { keychain } from '@libp2p/keychain'
 import { defaultLogger } from '@libp2p/logger'
 import { unixfs } from '@helia/unixfs'
@@ -177,12 +177,12 @@ class IpfsAdapter {
 
       const transports = [
         tcp(),
-        webSockets(),
-        circuitRelayTransport({
-          discoverRelays: 3,
-          reservationConcurrency: 3
-        }),
-        webRTC()
+        webSockets()
+        // circuitRelayTransport({
+        //   discoverRelays: 3,
+        //   reservationConcurrency: 3
+        // }),
+        // webRTC()
       ]
 
       // libp2p is the networking layer that underpins Helia


### PR DESCRIPTION
A bug with WebRTC transport is crashing the node. The issue is documented [here](https://github.com/libp2p/js-libp2p/issues/2702).