### PR TITLE
Separating E2E tests from Unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:all": "export SVC_ENV=test && c8 --reporter=text mocha --exit --timeout 15000 --recursive test/unit test/e2e/automated/",
     "test:unit": "export SVC_ENV=test && c8 --reporter=text mocha --exit --timeout 15000 --recursive test/unit/",
     "test:e2e:auto": "export SVC_ENV=test && mocha --exit --timeout 15000 test/e2e/automated/",
+    "start:e2e:server": "export SVC_ENV=test && node index.js",
     "test:temp": "export SVC_ENV=test && mocha --exit --timeout 15000 -g '#rate-limit' test/unit/json-rpc/",
     "lint": "standard --env mocha --fix",
     "docs": "./node_modules/.bin/apidoc -i src/ -o docs",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "start": "node index.js",
-    "test": "npm run test:all",
+    "test": "npm run test:unit",
     "test:all": "export SVC_ENV=test && c8 --reporter=text mocha --exit --timeout 15000 --recursive test/unit test/e2e/automated/",
     "test:unit": "export SVC_ENV=test && c8 --reporter=text mocha --exit --timeout 15000 --recursive test/unit/",
     "test:e2e:auto": "export SVC_ENV=test && mocha --exit --timeout 15000 test/e2e/automated/",

--- a/test/e2e/automated/a00-liveness.rest-e2e.js
+++ b/test/e2e/automated/a00-liveness.rest-e2e.js
@@ -4,8 +4,8 @@
 
 // Public npm libraries
 import { assert } from 'chai'
-
 import axios from 'axios'
+import testUtils from '../../utils/test-utils.js'
 
 // const sinon = require('sinon')
 
@@ -25,7 +25,20 @@ describe('#Check Server Liveness', () => {
       assert(response.status === 200, 'Server is running, continuing with E2E tests.')
     } catch (err) {
       console.log('\nServer is not running, exiting tests.')
-      console.log('Start the server with `npm start` before running E2E tests.\n')
+      console.log('Start the server with `npm run start:e2e:server` before running E2E tests.\n')
+      console.log('Ensure running npm run docs before running the test server')
+      process.exit(1)
+    }
+  })
+  it('should confirm the server is running over test enviroment', async () => {
+    try {
+      const res = await testUtils.loginAdminUser()
+      assert.property(res, 'user')
+      assert.property(res, 'token')
+      assert.property(res, 'id')
+    } catch (err) {
+      console.log('\nServer is not running over test enviroment, exiting tests.')
+      console.log('Start the server with `npm run start:e2e:server` before running E2E tests.\n')
       process.exit(1)
     }
   })

--- a/test/e2e/automated/a00-liveness.rest-e2e.js
+++ b/test/e2e/automated/a00-liveness.rest-e2e.js
@@ -1,0 +1,32 @@
+/*
+  Liveness test runs before all other tests to ensure the server is running.
+*/
+
+// Public npm libraries
+import { assert } from 'chai'
+
+import axios from 'axios'
+
+// const sinon = require('sinon')
+
+// Local support libraries
+import config from '../../../config/index.js'
+// import Server from '../../../bin/server.js'
+// import testUtils from '../../utils/test-utils.js'
+// const adminLib = new AdminLib()
+
+const LOCALHOST = `http://localhost:${config.port}`
+
+describe('#Check Server Liveness', () => {
+  // before(async () => {
+  it('should confirm the server is running', async () => {
+    try {
+      const response = await axios.get(`${LOCALHOST}/`)
+      assert(response.status === 200, 'Server is running, continuing with E2E tests.')
+    } catch (err) {
+      console.log('\nServer is not running, exiting tests.')
+      console.log('Start the server with `npm start` before running E2E tests.\n')
+      process.exit(1)
+    }
+  })
+})

--- a/test/e2e/automated/a01-auth.rest-e2e.js
+++ b/test/e2e/automated/a01-auth.rest-e2e.js
@@ -15,8 +15,6 @@ import axios from 'axios'
 import config from '../../../config/index.js'
 // import Server from '../../../bin/server.js'
 import testUtils from '../../utils/test-utils.js'
-import AdminLib from '../../../src/adapters/admin.js'
-const adminLib = new AdminLib()
 
 // const request = supertest.agent(app.listen())
 const context = {}
@@ -38,9 +36,6 @@ if (!config.noMongo) {
 
       // Delete all previous users in the database.
       await testUtils.deleteAllUsers()
-
-      // Create a new admin user.
-      await adminLib.createSystemUser()
 
       const userObj = {
         email: 'test@test.com',

--- a/test/e2e/automated/a01-auth.rest-e2e.js
+++ b/test/e2e/automated/a01-auth.rest-e2e.js
@@ -13,7 +13,7 @@ import axios from 'axios'
 
 // Local support libraries
 import config from '../../../config/index.js'
-import Server from '../../../bin/server.js'
+// import Server from '../../../bin/server.js'
 import testUtils from '../../utils/test-utils.js'
 import AdminLib from '../../../src/adapters/admin.js'
 const adminLib = new AdminLib()
@@ -26,10 +26,12 @@ const LOCALHOST = `http://localhost:${config.port}`
 if (!config.noMongo) {
   describe('Auth', () => {
     before(async () => {
-      const app = new Server()
+      // const app = new Server()
 
       // This should be the first instruction. It starts the REST API server.
-      await app.startServer()
+      // await app.startServer()
+
+      // TODO:
 
       // Stop the IPFS node for the rest of the e2e tests.
       // await app.controllers.adapters.ipfs.stop()

--- a/test/e2e/automated/a02-users.rest-e2e.js
+++ b/test/e2e/automated/a02-users.rest-e2e.js
@@ -166,64 +166,6 @@ if (!config.noMongo) {
         assert.property(result.data, 'token', 'Token property exists.')
         assert.equal(result.data.user.type, 'user')
       })
-      it('should reject signup when DISABLE_NEW_ACCOUNTS is true', async () => {
-        try {
-          process.env.DISABLE_NEW_ACCOUNTS = true
-          const options = {
-            method: 'POST',
-            url: `${LOCALHOST}/users`,
-            data: {
-              email: 'test2@test.com',
-              password: 'supersecretpassword',
-              name: 'test3'
-            }
-          }
-
-          await axios(options)
-
-          assert(false, 'Unexpected result')
-        } catch (err) {
-          console.log(err)
-          assert(err.response.status === 401, 'Error code 401 expected.')
-        }
-      })
-      it('admin can create a user when DISABLE_NEW_ACCOUNTS is true', async () => {
-        try {
-          process.env.DISABLE_NEW_ACCOUNTS = true
-          const options = {
-            method: 'post',
-            url: `${LOCALHOST}/users`,
-            headers: {
-              Authorization: `Bearer ${context.adminJWT}`
-            },
-            data: {
-              user: {
-                email: 'fromAdmin@test.com',
-                password: 'supersecretpassword',
-                name: 'test3'
-              }
-            }
-          }
-          const result = await axios(options)
-
-          context.user = result.data.user
-          context.token = result.data.token
-
-          assert(result.status === 200, 'Status Code 200 expected.')
-          assert(
-            result.data.user.email === 'fromAdmin@test.com',
-            'Email of test expected'
-          )
-          assert(
-            result.data.user.password === undefined,
-            'Password expected to be omited'
-          )
-          assert.property(result.data, 'token', 'Token property exists.')
-          assert.equal(result.data.user.type, 'user')
-        } catch (error) {
-          assert.fail('Unexpected code path')
-        }
-      })
     })
 
     describe('GET /users', () => {

--- a/test/e2e/automated/a02-users.rest-e2e.js
+++ b/test/e2e/automated/a02-users.rest-e2e.js
@@ -5,16 +5,11 @@ import axios from 'axios'
 import sinon from 'sinon'
 import util from 'util'
 
-import UserController from '../../../src/controllers/rest-api/users/controller.js'
-import Adapters from '../../../src/adapters/index.js'
-import UseCases from '../../../src/use-cases/index.js'
 util.inspect.defaultOptions = { depth: 1 }
 
 const LOCALHOST = `http://localhost:${config.port}`
 
 const context = {}
-const adapters = new Adapters()
-let uut
 let sandbox
 
 // const mockContext = require('../../unit/mocks/ctx-mock').context
@@ -50,9 +45,6 @@ if (!config.noMongo) {
     })
 
     beforeEach(() => {
-      const useCases = new UseCases({ adapters })
-      uut = new UserController({ adapters, useCases })
-
       sandbox = sinon.createSandbox()
     })
 
@@ -191,41 +183,46 @@ if (!config.noMongo) {
 
           assert(false, 'Unexpected result')
         } catch (err) {
+          console.log(err)
           assert(err.response.status === 401, 'Error code 401 expected.')
         }
       })
       it('admin can create a user when DISABLE_NEW_ACCOUNTS is true', async () => {
-        process.env.DISABLE_NEW_ACCOUNTS = true
-        const options = {
-          method: 'post',
-          url: `${LOCALHOST}/users`,
-          headers: {
-            Authorization: `Bearer ${context.adminJWT}`
-          },
-          data: {
-            user: {
-              email: 'fromAdmin@test.com',
-              password: 'supersecretpassword',
-              name: 'test3'
+        try {
+          process.env.DISABLE_NEW_ACCOUNTS = true
+          const options = {
+            method: 'post',
+            url: `${LOCALHOST}/users`,
+            headers: {
+              Authorization: `Bearer ${context.adminJWT}`
+            },
+            data: {
+              user: {
+                email: 'fromAdmin@test.com',
+                password: 'supersecretpassword',
+                name: 'test3'
+              }
             }
           }
+          const result = await axios(options)
+
+          context.user = result.data.user
+          context.token = result.data.token
+
+          assert(result.status === 200, 'Status Code 200 expected.')
+          assert(
+            result.data.user.email === 'fromAdmin@test.com',
+            'Email of test expected'
+          )
+          assert(
+            result.data.user.password === undefined,
+            'Password expected to be omited'
+          )
+          assert.property(result.data, 'token', 'Token property exists.')
+          assert.equal(result.data.user.type, 'user')
+        } catch (error) {
+          assert.fail('Unexpected code path')
         }
-        const result = await axios(options)
-
-        context.user = result.data.user
-        context.token = result.data.token
-
-        assert(result.status === 200, 'Status Code 200 expected.')
-        assert(
-          result.data.user.email === 'fromAdmin@test.com',
-          'Email of test expected'
-        )
-        assert(
-          result.data.user.password === undefined,
-          'Password expected to be omited'
-        )
-        assert.property(result.data, 'token', 'Token property exists.')
-        assert.equal(result.data.user.type, 'user')
       })
     })
 
@@ -320,33 +317,6 @@ if (!config.noMongo) {
 
         assert.hasAnyKeys(users[0], ['type', '_id', 'email'])
         assert.isNumber(users.length)
-      })
-
-      it('should return a 422 http status if biz-logic throws an error', async () => {
-        try {
-          const { token } = context
-
-          // Force an error
-          sandbox
-            .stub(uut.useCases.user, 'getAllUsers')
-            .rejects(new Error('test error'))
-
-          const options = {
-            method: 'GET',
-            url: `${LOCALHOST}/users`,
-            headers: {
-              Accept: 'application/json',
-              Authorization: `Bearer ${token}`
-            }
-          }
-          await axios(options)
-
-          assert.fail('Unexpected code path!')
-        } catch (err) {
-          // console.log(err)
-          assert.equal(err.response.status, 422)
-          assert.equal(err.response.data, 'test error')
-        }
       })
     })
 

--- a/test/e2e/automated/a09-admin.rest-e2e.js
+++ b/test/e2e/automated/a09-admin.rest-e2e.js
@@ -84,6 +84,7 @@ describe('Admin', () => {
           }
 
           sandbox.stub(uut.User, 'findOne').resolves(fakeUser)
+          sandbox.stub(uut.jsonFiles, 'writeJSON').resolves(true)
           const result = await uut.createSystemUser()
 
           assert.property(result, 'email')

--- a/test/unit/adapters/admin.adapter.unit.js
+++ b/test/unit/adapters/admin.adapter.unit.js
@@ -19,16 +19,16 @@ describe('Admin', () => {
 
   if (!config.noMongo) {
     describe('loginAdmin()', () => {
-      it('should logind admin', async () => {
-        try {
-          sandbox.stub(uut.axios, 'request').resolves(true)
+      // it('should login admin', async () => {
+      //   try {
+      //     sandbox.stub(uut.axios, 'request').resolves(true)
 
-          const result = await uut.loginAdmin()
-          assert.isTrue(result)
-        } catch (err) {
-          assert(false, 'Unexpected result')
-        }
-      })
+      //     const result = await uut.loginAdmin()
+      //     assert.isTrue(result)
+      //   } catch (err) {
+      //     assert(false, 'Unexpected result')
+      //   }
+      // })
 
       it('should handle axios error', async () => {
         try {

--- a/test/unit/adapters/admin.adapter.unit.js
+++ b/test/unit/adapters/admin.adapter.unit.js
@@ -21,24 +21,10 @@ describe('Admin', () => {
     describe('loginAdmin()', () => {
       it('should logind admin', async () => {
         try {
-          const error = new Error('test error')
-          error.response = {
-            status: 422
-          }
-          // sandbox.stub(uut.axios, 'request').onFirstCall().throws(error)
+          sandbox.stub(uut.axios, 'request').resolves(true)
 
           const result = await uut.loginAdmin()
-          const user = result.data.user
-
-          assert.property(user, '_id')
-          assert.property(user, 'email')
-          assert.property(user, 'type')
-
-          assert.isString(user._id)
-          assert.isString(user.email)
-          assert.isString(user.type)
-
-          assert.equal(user.type, 'admin')
+          assert.isTrue(result)
         } catch (err) {
           assert(false, 'Unexpected result')
         }
@@ -48,13 +34,13 @@ describe('Admin', () => {
         try {
           // Returns an erroneous password to force
           // an auth error
+          sandbox.stub(uut.axios, 'request').throws(new Error('test error'))
           sandbox.stub(uut.jsonFiles, 'readJSON').resolves({ password: 'wrong' })
 
           await uut.loginAdmin()
           assert(false, 'Unexpected result')
         } catch (err) {
-          assert.equal(err.response.status, 401)
-          assert.include(err.response.data, 'Unauthorized')
+          assert.include(err.message, 'test error')
         }
       })
     })

--- a/test/unit/controllers/rest-api/users/users.rest.router.unit.js
+++ b/test/unit/controllers/rest-api/users/users.rest.router.unit.js
@@ -79,4 +79,32 @@ describe('#Users-REST-Router', () => {
       }
     })
   })
+
+  describe('#createUser', () => {
+    it('should ignore admin validator when DISABLE_NEW_ACCOUNTS is not defined', async () => {
+      // Stub functions
+      const validationSpy = sandbox.stub(uut.validators, 'ensureAdmin').resolves(true)
+      sandbox.stub(uut.userRESTController, 'createUser').resolves(true)
+
+      // Call function
+      await uut.createUser()
+
+      // Assertions
+      assert.isTrue(validationSpy.notCalled, 'Admin validator should not be called')
+    })
+    it('should ensure admin when DISABLE_NEW_ACCOUNTS is defined', async () => {
+      // Set environment variable
+      process.env.DISABLE_NEW_ACCOUNTS = true
+
+      // Stub functions
+      const validationSpy = sandbox.stub(uut.validators, 'ensureAdmin').resolves(true)
+      sandbox.stub(uut.userRESTController, 'createUser').resolves(true)
+
+      // Call function
+      await uut.createUser()
+
+      // Assertions
+      assert.isTrue(validationSpy.calledOnce, 'Admin validator should be called')
+    })
+  })
 })

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -8,7 +8,6 @@ import axios from 'axios'
 
 // Local libraries
 import config from '../../config/index.js'
-import User from '../../src/adapters/localdb/models/users.js'
 import JsonFiles from '../../src/adapters/json-files.js'
 
 // Hack to get __dirname back.
@@ -30,24 +29,6 @@ async function cleanDb () {
 
       await collection.deleteMany()
     }
-  }
-}
-
-// Delete all users in the database. This ensures there is no previous state
-// to confuse tests.
-async function deleteAllUsers () {
-  try {
-    // Get all the users in the DB.
-    const users = await User.find({}, '-password')
-    // console.log(`users: ${JSON.stringify(users, null, 2)}`)
-
-    // Delete each user.
-    for (let i = 0; i < users.length; i++) {
-      const thisUser = users[i]
-      await thisUser.remove()
-    }
-  } catch (err) {
-    console.error('Error in test-utils.js/deleteAllUsers(): ', err)
   }
 }
 
@@ -170,12 +151,56 @@ async function getAdminJWT () {
     throw err
   }
 }
+// Fetches all users from the database.
+async function getAllUsers () {
+  try {
+    const adminJWT = await getAdminJWT()
+    const options = {
+      method: 'GET',
+      url: `${LOCALHOST}/users`,
+      headers: {
+        Authorization: `Bearer ${adminJWT}`
+      }
+    }
+    const result = await axios(options)
+    return result.data.users
+  } catch (err) {
+    console.error('Error in test/utils.js/getAllUsers()', err)
+    throw err
+  }
+}
 
+// Deletes all users from the database.
+async function deleteAllUsers () {
+  try {
+    const allUsers = await getAllUsers()
+    const adminJWT = await getAdminJWT()
+    for (let i = 0; i < allUsers.length; i++) {
+      const user = allUsers[i]
+      // Skip the admin user.
+      if (user.type === 'admin') {
+        continue
+      }
+      const options = {
+        method: 'DELETE',
+        url: `${LOCALHOST}/users/${user._id}`,
+        headers: {
+          Authorization: `Bearer ${adminJWT}`
+        }
+      }
+      await axios(options)
+    }
+  } catch (err) {
+    console.error('Error in test/utils.js/deleteAllUsers()', err)
+    throw err
+  }
+}
 export default {
   cleanDb,
   createUser,
   loginTestUser,
   loginAdminUser,
   getAdminJWT,
-  deleteAllUsers
+  deleteAllUsers,
+  getAllUsers
 }

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -47,7 +47,7 @@ async function deleteAllUsers () {
       await thisUser.remove()
     }
   } catch (err) {
-    console.error('Error in test-utils.js/deleteAllUsers()')
+    console.error('Error in test-utils.js/deleteAllUsers(): ', err)
   }
 }
 


### PR DESCRIPTION
Currently the e2e and unit tests are run together when the `npm test` command is run. The combined tests achieve 100% unit test coverage.

This PR separates the e2e tests from the unit test. It never felt right to combine them. This will temporarily lower the code coverage but will allow for cleaner separation of concerns, and long-term, it will provide better test coverage.